### PR TITLE
container: Keep track of rounding error in stretch calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "alignments"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "eframe",
  "egui",
@@ -189,7 +189,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "containers"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "eframe",
  "egui",
@@ -890,9 +890,10 @@ dependencies = [
 
 [[package]]
 name = "egui_alignments"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "egui",
+ "egui_kittest",
 ]
 
 [[package]]
@@ -927,6 +928,16 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "winit",
+]
+
+[[package]]
+name = "egui_kittest"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ca7eb7521658cb9714724de1de199be864a1eafe29218ecd5b22db2f4f8400"
+dependencies = [
+ "egui",
+ "kittest",
 ]
 
 [[package]]
@@ -1640,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1700,6 +1711,17 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kittest"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fd6dd2cce251a360101038acb9334e3a50cd38cd02fefddbf28aa975f043c8"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "parking_lot",
+]
 
 [[package]]
 name = "kurbo"
@@ -2704,7 +2726,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ eframe = "0.33"
 egui = "0.33"
 egui_alignments = { path = "crates/egui_alignments" }
 egui_extras = { version = "0.33", features = ["all_loaders"] }
+egui_kittest = "0.33"

--- a/crates/egui_alignments/Cargo.toml
+++ b/crates/egui_alignments/Cargo.toml
@@ -11,3 +11,6 @@ license.workspace = true
 
 [dependencies]
 egui = { workspace = true }
+
+[dev-dependencies]
+egui_kittest = { workspace = true }

--- a/crates/egui_alignments/src/container.rs
+++ b/crates/egui_alignments/src/container.rs
@@ -24,9 +24,9 @@ pub mod row;
 pub use column::*;
 pub use row::*;
 
-use egui::{Id, InnerResponse, Layout, Sense, Ui, UiBuilder, Vec2};
-
 use crate::resize_layout_rect;
+use egui::emath::GuiRounding;
+use egui::{Id, InnerResponse, Layout, Sense, Ui, UiBuilder, Vec2};
 
 pub struct Container {
     pub id: Option<Id>,
@@ -224,13 +224,22 @@ fn prepare_stretch(ui: &mut Ui, available_space: f32) -> Option<Vec<f32>> {
         // if the layout is wrapped, we consider that there is no space left
         available_space = 0.0;
     }
-    let last_weights_sum: f32 = last_weights.iter().sum();
+    let total_weight: f32 = last_weights.iter().sum();
 
     // calculate sizes
+    let mut cumulative_weight = 0.0;
+    let mut cumulative_rounded = 0.0;
     let mut spaces = Vec::with_capacity(last_weights.len());
     for weight in last_weights.iter() {
-        let space = available_space * weight / last_weights_sum;
-        spaces.push(space);
+        // egui rounds lengths given to add_space (and in general) using round_ui(). The
+        // individually rounded spaces will not necessarily add up to the same as the original
+        // available_space. Therefore, keep track of the accumulated error to ensure that the
+        // rounded spaces will average out to the original total.
+        cumulative_weight += weight;
+        let cumulative_space = available_space * (cumulative_weight / total_weight);
+        let rounded = cumulative_space.round_ui() - cumulative_rounded;
+        cumulative_rounded += rounded;
+        spaces.push(rounded);
     }
 
     // prepare data for stretch

--- a/crates/egui_alignments/tests/container.rs
+++ b/crates/egui_alignments/tests/container.rs
@@ -1,0 +1,35 @@
+use egui::{Align, Rect};
+use egui_alignments::{stretch, Row};
+use egui_kittest::kittest::Queryable;
+use egui_kittest::Harness;
+use std::cell::Cell;
+
+#[test]
+fn container_stretch_rounding() {
+    let container_rect = Cell::new(Rect::NAN);
+
+    let mut harness = Harness::builder().with_size([750.0, 60.0]).build_ui(|ui| {
+        let res = Row::new(Align::Min).wrapping(true).show(ui, |ui| {
+            for i in 0..=8 {
+                if i == 4 || i == 6 {
+                    stretch(ui);
+                }
+                let _ = ui.button(format!("Button {i}"));
+            }
+        });
+        container_rect.set(res.response.rect);
+    });
+
+    // Run several times to check the layout is stable across frames
+    for _ in 0..4 {
+        // Check all buttons are on the same line
+        let buttons = harness.get_all_by_label_contains("Button");
+        assert!(buttons.is_sorted_by(|l, r| l.rect().top() == r.rect().top()));
+
+        // Check that the layout is stretched across the full row
+        let button = harness.get_by_label("Button 8");
+        assert_eq!(button.rect().right(), container_rect.get().right());
+
+        harness.step();
+    }
+}


### PR DESCRIPTION
See commit description:

> egui rounds lengths to the nearest 1/32th (GUI_ROUNDING). This caused
> calculated spaces in stretches to sometimes (after rounding) add up to
> more than the actual available space, causing the UI to oscillate
> between wrapped and non-wrapped states on each update. Fix this by
> keeping track of the error relative to the rounded amounts during the
> sum, ensuring that it will average out and spaces will add up to exactly
> the available space.

For whatever reason this caused issues for me mostly only with wrapping layouts, but it should improve reliability of the layout in general too.

I also added a test using egui_kittest which was failing before, to validate the change.